### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(),tailwindcss()],
+  base: '/evevo-tech/',
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
This fixes the deployment issue by setting the correct base path in vite.config.js for GitHub Pages. The website was showing a blank page because the JavaScript and CSS assets were not loading due to incorrect paths.